### PR TITLE
Bidirectional Topic Sync, Topic Change Messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Connects [Discord](https://discordapp.com/) and [IRC](https://www.ietf.org/rfc/rfc1459.txt) channels by sending messages back and forth.
 
->This is an **opinionated** fork that adds irc -> discord channel topic syncing and a setting to disable username stripping from !commands sent from irc -> discord.
+>This is an **opinionated** fork that adds bidirectional channel topic syncing, a topic change alert message, and a setting to disable username stripping from !commands sent from irc -> discord.
 
 ## Example
 ![discord-irc](http://i.imgur.com/oI6iCrf.gif)
@@ -96,9 +96,12 @@ First you need to create a Discord bot user, which you can do by following the i
     // Useful for discord channels with bot commands, annoying for ones that don't
     // Defaults to true.
     "discordCommandFormatting": true,
-    // One-way syncing of IRC to discord channel topics. Defaults to false.
-    // This feature REQUIRES the bot be in a roll with "Manage Channels" permission for the guild!
-    "syncDiscordTopic": false,
+    // Bi-directional syncing of channel topics. Defaults to false.
+    // This feature REQUIRES the bot be in a roll with "Manage Channels" permission for the guild on discord
+    // and have proper permissions to change the channel topic in IRC.
+    "syncTopic": false,
+    // Post a simple (non-pinging) message in discord when the topic is changed
+    "topicAlert": false,
     "ircStatusNotices": true, // Enables notifications in Discord when people join/part in the relevant IRC channel
     "ignoreUsers": {
       "irc": ["irc_nick1", "irc_nick2"], // Ignore specified IRC nicks and do not send their messages to Discord.

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -160,7 +160,9 @@ class Bot {
     });
 
     this.discord.on("channelUpdate", (oldChannel, newChannel) => {
-      logger.debug("Recieved channelUpdate in discord: %s -> %s", oldChannel.topic, newChannel.topic);
+      logger.debug("Recieved channelUpdate in discord.", oldChannel.topic, newChannel.topic, this.dirtyTopic);
+      // swap newlines with space since IRC can't handle multi-line topics
+      const topic = newChannel.topic.replace(/\n/g, " ");
       if (this.syncDiscordTopic && !this.dirtyTopic) {
         const channelName = `#${newChannel.name}`;
         const ircChannel = this.channelMapping[newChannel.id] ||
@@ -182,15 +184,14 @@ class Bot {
           }
           logger.debug("Different topics!");
         }
-        logger.debug("Updating IRC topic to:", newChannel.topic);
-        // swap newlines with space since IRC can't handle multi-line topics
-        const topic = newChannel.topic.replace(/\n/g, " ");
+        logger.debug("Updating IRC topic.", newChannel.topic);
         this.ircClient.send('topic', ircChannel, topic);
         // set the dirty flag to prevent loops as IRC and discord update
         this.dirtyTopic = true;
       }
       // now that we've skipped the topic update loop, mark topic as clean
       else {
+        newChannel.send(`:bell: Topic Updated: ${topic}`);
         this.dirtyTopic = false;
       }
     });
@@ -282,13 +283,13 @@ class Bot {
     });
 
     this.ircClient.on('topic', (channelName, topic) => {
-      logger.debug('Received topic change in IRC.', channelName, topic);
+      logger.debug('Received topic change in IRC.', channelName, topic, this.dirtyTopic);
+      const channel = channelName.toLowerCase();
       if (this.syncDiscordTopic && !this.dirtyTopic) {
-        const channel = channelName.toLowerCase();
         this.updateDiscordTopic(channel, topic);
-        this.dirtyTopic = true;
       }
       else {
+        this.sendExactToDiscord(channel, `:bell: Topic Updated: ${topic}`);
         this.dirtyTopic = false;
       }
     });
@@ -645,6 +646,7 @@ class Bot {
     }
     logger.debug('Changing discord channel topic to %s', topic);
     discordChannel.setTopic(topic);
+    this.dirtyTopic = true;
   }
 
   /* Sends a message to Discord exactly as it appears */

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -42,8 +42,11 @@ class Bot {
     // Pass on command formatting to discord server, defaults to true.
     this.discordCommandFormatting = options.discordCommandFormatting !== false;
 
-    // Sync IRC channel topic updates to their discord partners. Defaults to false.
-    this.syncDiscordTopic = options.syncDiscordTopic === true;
+    // Sync IRC channel topic updates to their discord partners and vice versa. Defaults to false.
+    this.syncTopic = options.syncTopic === true;
+
+    // Send a short message to discord to announce topic changes. Defaults to false.
+    this.topicAlert = options.topicAlert === true;
 
     // Nicks to ignore
     this.ignoreUsers = options.ignoreUsers || {};
@@ -163,13 +166,13 @@ class Bot {
       logger.debug("Recieved channelUpdate in discord.", oldChannel.topic, newChannel.topic, this.dirtyTopic);
       // swap newlines with space since IRC can't handle multi-line topics
       const topic = newChannel.topic.replace(/\n/g, " ");
-      if (this.syncDiscordTopic && !this.dirtyTopic) {
+      if (this.syncTopic && !this.dirtyTopic) {
         const channelName = `#${newChannel.name}`;
         const ircChannel = this.channelMapping[newChannel.id] ||
                                               this.channelMapping[channelName];
 
         if(oldChannel.topic && newChannel.topic) {
-          logger.debug("Comparing non-null topics..", oldChannel.topic, newChannel.topic);
+          logger.debug("Comparing non-null topics.", oldChannel.topic, newChannel.topic);
           if (oldChannel.topic.trim() === newChannel.topic.trim()) {
             logger.debug('Trying to set identical topic. Aborting!')
             return;
@@ -191,7 +194,7 @@ class Bot {
       }
       // now that we've skipped the topic update loop, mark topic as clean
       else {
-        newChannel.send(`:bell: Topic Updated: ${topic}`);
+        if (this.topicAlert) newChannel.send(`:bell: Topic Updated: ${topic}`);
         this.dirtyTopic = false;
       }
     });
@@ -285,11 +288,11 @@ class Bot {
     this.ircClient.on('topic', (channelName, topic) => {
       logger.debug('Received topic change in IRC.', channelName, topic, this.dirtyTopic);
       const channel = channelName.toLowerCase();
-      if (this.syncDiscordTopic && !this.dirtyTopic) {
+      if (this.syncTopic && !this.dirtyTopic) {
         this.updateDiscordTopic(channel, topic);
       }
       else {
-        this.sendExactToDiscord(channel, `:bell: Topic Updated: ${topic}`);
+        if (this.topicAlert) this.sendExactToDiscord(channel, `:bell: Topic Updated: ${topic}`);
         this.dirtyTopic = false;
       }
     });

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -37,6 +37,7 @@ class Bot {
     this.ircStatusNotices = options.ircStatusNotices;
     this.announceSelfJoin = options.announceSelfJoin;
     this.webhookOptions = options.webhooks;
+    this.dirtyTopic = false;
 
     // Pass on command formatting to discord server, defaults to true.
     this.discordCommandFormatting = options.discordCommandFormatting !== false;
@@ -158,6 +159,42 @@ class Bot {
       this.sendToIRC(message);
     });
 
+    this.discord.on("channelUpdate", (oldChannel, newChannel) => {
+      logger.debug("Recieved channelUpdate in discord: %s -> %s", oldChannel.topic, newChannel.topic);
+      if (this.syncDiscordTopic && !this.dirtyTopic) {
+        const channelName = `#${newChannel.name}`;
+        const ircChannel = this.channelMapping[newChannel.id] ||
+                                              this.channelMapping[channelName];
+
+        if(oldChannel.topic && newChannel.topic) {
+          logger.debug("Comparing non-null topics..", oldChannel.topic, newChannel.topic);
+          if (oldChannel.topic.trim() === newChannel.topic.trim()) {
+            logger.debug('Trying to set identical topic. Aborting!')
+            return;
+          }
+          logger.debug("Different topics!");
+        }
+        else {
+          logger.debug("Comparing null topics..", oldChannel.topic, newChannel.topic);
+          if (oldChannel.topic === newChannel.topic) {
+            logger.debug('Trying to set identical empty topic. Aborting!')
+            return;
+          }
+          logger.debug("Different topics!");
+        }
+        logger.debug("Updating IRC topic to:", newChannel.topic);
+        // swap newlines with space since IRC can't handle multi-line topics
+        const topic = newChannel.topic.replace(/\n/g, " ");
+        this.ircClient.send('topic', ircChannel, topic);
+        // set the dirty flag to prevent loops as IRC and discord update
+        this.dirtyTopic = true;
+      }
+      // now that we've skipped the topic update loop, mark topic as clean
+      else {
+        this.dirtyTopic = false;
+      }
+    });
+
     this.ircClient.on('message', this.sendToDiscord.bind(this));
 
     this.ircClient.on('notice', (author, to, text) => {
@@ -245,10 +282,14 @@ class Bot {
     });
 
     this.ircClient.on('topic', (channelName, topic) => {
-      logger.debug('Received topic change:', channelName, topic);
-      if (this.syncDiscordTopic) {
+      logger.debug('Received topic change in IRC.', channelName, topic);
+      if (this.syncDiscordTopic && !this.dirtyTopic) {
         const channel = channelName.toLowerCase();
         this.updateDiscordTopic(channel, topic);
+        this.dirtyTopic = true;
+      }
+      else {
+        this.dirtyTopic = false;
       }
     });
 
@@ -578,13 +619,31 @@ class Bot {
   /* Changes the topic of the given discord channel to the supplied topic string.
      Requires the Manage Channels permission for the guild in order to work. */
   updateDiscordTopic(channel, topic) {
+    logger.debug("Starting updateDiscordTopic.", topic);
     const discordChannel = this.findDiscordChannel(channel);
     if (!discordChannel) {
       logger.debug('Cannot find discord channel! Aborting topic update!');
       return;
     }
-
-    logger.debug('Changing discord channel topic to', topic, channel, '->', `#${discordChannel.name}`);
+    // if both topics are non-null
+    logger.debug("Comparing topics", discordChannel.topic, topic);
+    if(discordChannel.topic && topic) {
+      logger.debug("Testing topic equality, non-null.")
+      if (discordChannel.topic.trim() === topic.trim()) {
+        logger.debug('Trying to set identical topic. Aborting!')
+        return;
+      }
+      logger.debug("Different topics!");
+    }
+    else {
+      logger.debug("Testing topic equality, null.")
+      if (discordChannel.topic === topic) {
+        logger.debug('Trying to set identical empty topic. Aborting!')
+        return;
+      }
+      logger.debug("Different topics!");
+    }
+    logger.debug('Changing discord channel topic to %s', topic);
     discordChannel.setTopic(topic);
   }
 

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,11 +1,15 @@
 import winston, { format } from 'winston';
+import { inspect } from 'util';
 
 function formatter(info) {
-  const stringifiedRest = JSON.stringify(Object.assign({}, info, {
-    level: undefined,
-    message: undefined,
-    splat: undefined
-  }));
+  const stringifiedRest = inspect(
+    Object.assign({}, info, {
+      level: undefined,
+      message: undefined,
+      splat: undefined
+    }),
+    { depth: null }
+  );
 
   const padding = (info.padding && info.padding[info.level]) || '';
   if (stringifiedRest !== '{}') {


### PR DESCRIPTION
The fork this repo was sourced from has been updated with bidirectional topic syncing and the addition of a short message that is posted in an associated discord channel upon topic change.

The only changes that need to happen after updating your source and rebuilding are as follows:

1. The config.json file will require the removal of the old syncDiscordTopic setting and the addition of a new couple new settings as shown:
```
    "syncTopic": true,
    "topicAlert": true,
```
2. Add the irc-bot account to auto-op in your channel on quakenet so it can access the topic and make sure the discord-bot has the "Manage Channels" and 'Send Messages" role permissions for its guild so it can change the topic and post the bridged messages.

After that, just restart it during a quiet hour and everything should be good to go!

